### PR TITLE
Add dynamic gas estimation

### DIFF
--- a/src/connectors/panoptic/panoptic.config.ts
+++ b/src/connectors/panoptic/panoptic.config.ts
@@ -4,8 +4,8 @@ import { ConfigManagerV2 } from '../../services/config-manager-v2';
 export namespace PanopticConfig {
   export interface NetworkConfig {
     allowedSlippage: string;
-    gasLimitEstimate: number;
-    gasFactor: number; 
+    absoluteGasLimit: number;
+    gasLimitCushionFactor: number; 
     ttl: number;
     subgraphUrl: string;
     lowestTick: number;
@@ -26,8 +26,8 @@ export namespace PanopticConfig {
 
   export const config: NetworkConfig = {
     allowedSlippage: ConfigManagerV2.getInstance().get('panoptic.allowedSlippage'),
-    gasFactor: ConfigManagerV2.getInstance().get('panoptic.gasFactor'),
-    gasLimitEstimate: ConfigManagerV2.getInstance().get(`panoptic.gasLimitEstimate`),
+    gasLimitCushionFactor: ConfigManagerV2.getInstance().get('panoptic.gasLimitCushionFactor'),
+    absoluteGasLimit: ConfigManagerV2.getInstance().get(`panoptic.absoluteGasLimit`),
     ttl: ConfigManagerV2.getInstance().get('panoptic.ttl'),
     subgraphUrl: ConfigManagerV2.getInstance().get('panoptic.subgraph.endpoint'),
     lowestTick: ConfigManagerV2.getInstance().get('panoptic.lowestTick'),

--- a/src/connectors/panoptic/panoptic.config.ts
+++ b/src/connectors/panoptic/panoptic.config.ts
@@ -5,6 +5,7 @@ export namespace PanopticConfig {
   export interface NetworkConfig {
     allowedSlippage: string;
     gasLimitEstimate: number;
+    gasFactor: number; 
     ttl: number;
     subgraphUrl: string;
     lowestTick: number;
@@ -24,13 +25,9 @@ export namespace PanopticConfig {
   }
 
   export const config: NetworkConfig = {
-    allowedSlippage: ConfigManagerV2.getInstance().get(
-      'panoptic.allowedSlippage'
-    ),
-    // TODO: Add a getTransactionGasLimitEstimate(unsignedTransactionPayload) here
-    gasLimitEstimate: ConfigManagerV2.getInstance().get(
-      `panoptic.gasLimitEstimate`
-    ),
+    allowedSlippage: ConfigManagerV2.getInstance().get('panoptic.allowedSlippage'),
+    gasFactor: ConfigManagerV2.getInstance().get('panoptic.gasFactor'),
+    gasLimitEstimate: ConfigManagerV2.getInstance().get(`panoptic.gasLimitEstimate`),
     ttl: ConfigManagerV2.getInstance().get('panoptic.ttl'),
     subgraphUrl: ConfigManagerV2.getInstance().get('panoptic.subgraph.endpoint'),
     lowestTick: ConfigManagerV2.getInstance().get('panoptic.lowestTick'),

--- a/src/connectors/panoptic/panoptic.controllers.ts
+++ b/src/connectors/panoptic/panoptic.controllers.ts
@@ -844,7 +844,7 @@ export async function burn(
     }
 
     logger.info(
-      `Burn has been executed, txHash is ${tx.transactionHash}, nonce is ${tx.transactionIndex}, gasPrice is ${gasPrice}, gas used is ${tx.cumulativeGasUsed}.`
+      `Burn has been executed, txHash is ${tx.transactionHash}, nonce is ${tx.transactionIndex}, gasPrice is ${gasPrice}, gas used is ${tx.gasUsed}.`
     );
 
     return {
@@ -891,7 +891,7 @@ export async function forceExercise(
     }
 
     logger.info(
-      `forceExercise has been executed, txHash is ${tx.transactionHash}, nonce is ${tx.transactionIndex}, gasPrice is ${gasPrice}, gas used is ${tx.cumulativeGasUsed}.`
+      `forceExercise has been executed, txHash is ${tx.transactionHash}, nonce is ${tx.transactionIndex}, gasPrice is ${gasPrice}, gas used is ${tx.gasUsed}.`
     );
 
     return {
@@ -939,7 +939,7 @@ export async function liquidate(
     }
 
     logger.info(
-      `Liquidation has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.cumulativeGasUsed}.`
+      `Liquidation has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.gasUsed}.`
     );
 
     return {
@@ -986,7 +986,7 @@ export async function mint(
     }
 
     logger.info(
-      `Mint has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.cumulativeGasUsed}.`
+      `Mint has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.gasUsed}.`
     );
 
     return {
@@ -1071,7 +1071,7 @@ export async function pokeMedian(
     }
 
     logger.info(
-      `pokeMedian has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.cumulativeGasUsed}.`
+      `pokeMedian has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.gasUsed}.`
     );
 
     return {
@@ -1118,7 +1118,7 @@ export async function settleLongPremium(
     }
 
     logger.info(
-      `settleLongPremium has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.cumulativeGasUsed}.`
+      `settleLongPremium has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.gasUsed}.`
     );
 
     return {
@@ -1166,7 +1166,7 @@ export async function deposit(
     }
 
     logger.info(
-      `deposit has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.cumulativeGasUsed}.`
+      `deposit has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.gasUsed}.`
     );
 
     return {
@@ -1211,7 +1211,7 @@ export async function getAsset(
     }
 
     logger.info(
-      `getAsset has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.cumulativeGasUsed}.`
+      `getAsset has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.gasUsed}.`
     );
 
     return {
@@ -1301,7 +1301,7 @@ export async function withdraw(
     }
 
     logger.info(
-      `withdraw has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.cumulativeGasUsed}.`
+      `withdraw has been executed, txHash is ${tx.transactionHash}, gasPrice is ${gasPrice}, gas used is ${tx.gasUsed}.`
     );
 
     return {

--- a/src/connectors/panoptic/panoptic.controllers.ts
+++ b/src/connectors/panoptic/panoptic.controllers.ts
@@ -130,7 +130,7 @@ export async function estimateGas(
   panopticish: Panoptic,
 ): Promise<EstimateGasResponse | Error> {
   const gasPrice: number = ethereumish.gasPrice;
-  const gasLimit: number = panopticish.gasLimitEstimate;
+  const gasLimit: number = panopticish.absoluteGasLimit;
   return {
     network: ethereumish.chain,
     timestamp: Date.now(),

--- a/src/connectors/panoptic/panoptic.ts
+++ b/src/connectors/panoptic/panoptic.ts
@@ -889,22 +889,23 @@ export class Panoptic {
     try {
       const panopticpool = this.PanopticPool;
       const panopticPoolContract = new Contract(panopticpool, panopticPoolAbi.abi, wallet);
-      const gasEstimate: number = (await panopticPoolContract["burnOptions(uint256,uint256[],int24,int24)"].estimateGas.burnOptions(
-        burnTokenId,
-        newPositionIdList,
-        tickLimitLow,
-        tickLimitHigh
-      )).toNumber();
-      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      if (gasLimit > this.gasLimitEstimate) {
-        return new Error(`Error on executeBurn: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
-      }
+      // const gasEstimate: number = (await panopticPoolContract.estimateGas.panopticPoolContract["burnOptions(uint256,uint256[],int24,int24)"](
+      //   burnTokenId,
+      //   newPositionIdList,
+      //   tickLimitLow,
+      //   tickLimitHigh
+      // )).toNumber();
+      // const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      // if (gasLimit > this.gasLimitEstimate) {
+      //   return new Error(`Error on executeBurn: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      // }
       const tx: ContractTransaction = await panopticPoolContract["burnOptions(uint256,uint256[],int24,int24)"](
         burnTokenId,
         newPositionIdList,
         tickLimitLow,
         tickLimitHigh,
-        { gasLimit: BigNumber.from(gasLimit) }
+        { gasLimit: this.gasLimitEstimate }
+        // { gasLimit: BigNumber.from(gasLimit) }
       );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;

--- a/src/connectors/panoptic/panoptic.ts
+++ b/src/connectors/panoptic/panoptic.ts
@@ -32,8 +32,8 @@ export class Panoptic {
   private _UniswapMigrator: string;
   private _PanopticPool: string;
   private _TokenIdLibrary: string;
-  private _gasLimitEstimate: number;
-  private _gasFactor: number;
+  private _absoluteGasLimit: number;
+  private _gasLimitCushionFactor: number;
   private _ttl: number;
   private _subgraphUrl: string;
   private _lowestTick: number;
@@ -61,8 +61,8 @@ export class Panoptic {
     this._subgraphUrl = config.subgraphUrl;
     this._lowestTick = config.lowestTick;
     this._highestTick = config.highestTick;
-    this._gasLimitEstimate = config.gasLimitEstimate;
-    this._gasFactor = config.gasFactor;
+    this._absoluteGasLimit = config.absoluteGasLimit;
+    this._gasLimitCushionFactor = config.gasLimitCushionFactor;
   }
 
   public static getInstance(chain: string, network: string): Panoptic {
@@ -147,11 +147,11 @@ export class Panoptic {
   public get HIGHEST_POSSIBLE_TICK(): number {
     return this._highestTick;
   }
-  public get gasLimitEstimate(): number {
-    return this._gasLimitEstimate;
+  public get absoluteGasLimit(): number {
+    return this._absoluteGasLimit;
   }
-  public get gasFactor(): number {
-    return this._gasFactor;
+  public get gasLimitCushionFactor(): number {
+    return this._gasLimitCushionFactor;
   }
   public get ttl(): number {
     return this._ttl;
@@ -895,9 +895,9 @@ export class Panoptic {
         tickLimitLow,
         tickLimitHigh
       )).toNumber();
-      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      if (gasLimit > this.gasLimitEstimate) {
-        return new Error(`Error on executeBurn: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      const gasLimit: number = Math.ceil(this.gasLimitCushionFactor * gasEstimate);
+      if (gasLimit > this.absoluteGasLimit) {
+        return new Error(`Error on executeBurn: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.absoluteGasLimit})...`);
       }
       const tx: ContractTransaction = await panopticPoolContract["burnOptions(uint256,uint256[],int24,int24)"](
         burnTokenId,
@@ -928,9 +928,9 @@ export class Panoptic {
         positionIdListExercisee,
         positionIdListExercisor
       )).toNumber();
-      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      if (gasLimit > this.gasLimitEstimate) {
-        return new Error(`Error on forceExercise: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      const gasLimit: number = Math.ceil(this.gasLimitCushionFactor * gasEstimate);
+      if (gasLimit > this.absoluteGasLimit) {
+        return new Error(`Error on forceExercise: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.absoluteGasLimit})...`);
       }
       const tx: ContractTransaction = await panopticPoolContract.forceExercise(
         wallet.address,
@@ -962,9 +962,9 @@ export class Panoptic {
         delegations,
         positionIdList
       )).toNumber();
-      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      if (gasLimit > this.gasLimitEstimate) {
-        return new Error(`Error on liquidate: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      const gasLimit: number = Math.ceil(this.gasLimitCushionFactor * gasEstimate);
+      if (gasLimit > this.absoluteGasLimit) {
+        return new Error(`Error on liquidate: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.absoluteGasLimit})...`);
       }
       const tx: ContractTransaction = await panopticPoolContract.liquidate(
         positionIdListLiquidator,
@@ -998,9 +998,9 @@ export class Panoptic {
         tickLimitLow,
         tickLimitHigh
       )).toNumber();
-      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      if (gasLimit > this.gasLimitEstimate) {
-        return new Error(`Error on executeMint: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      const gasLimit: number = Math.ceil(this.gasLimitCushionFactor * gasEstimate);
+      if (gasLimit > this.absoluteGasLimit) {
+        return new Error(`Error on executeMint: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.absoluteGasLimit})...`);
       }
       const tx: ContractTransaction = await panopticPoolContract.mintOptions(
         positionIdList,
@@ -1052,9 +1052,9 @@ export class Panoptic {
       const panopticpool = this.PanopticPool;
       const panopticPoolContract = new Contract(panopticpool, panopticPoolAbi.abi, wallet);
       const gasEstimate: number = (await panopticPoolContract.estimateGas.pokeMedian()).toNumber();
-      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      if (gasLimit > this.gasLimitEstimate) {
-        return new Error(`Error on pokeMedian: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      const gasLimit: number = Math.ceil(this.gasLimitCushionFactor * gasEstimate);
+      if (gasLimit > this.absoluteGasLimit) {
+        return new Error(`Error on pokeMedian: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.absoluteGasLimit})...`);
       }
       const tx: ContractTransaction = await panopticPoolContract.pokeMedian(
         { gasLimit: BigNumber.from(gasLimit)}
@@ -1080,9 +1080,9 @@ export class Panoptic {
         owner,
         legIndex
       )).toNumber();
-      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      if (gasLimit > this.gasLimitEstimate) {
-        return new Error(`Error on settleLongPremium: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      const gasLimit: number = Math.ceil(this.gasLimitCushionFactor * gasEstimate);
+      if (gasLimit > this.absoluteGasLimit) {
+        return new Error(`Error on settleLongPremium: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.absoluteGasLimit})...`);
       }
       const tx: ContractTransaction = await panopticPoolContract.settleLongPremium(
         positionIdList,
@@ -1109,9 +1109,9 @@ export class Panoptic {
         assets, 
         wallet.address
       )).toNumber();
-      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      if (gasLimit > this.gasLimitEstimate) {
-        return new Error(`Error on deposit: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      const gasLimit: number = Math.ceil(this.gasLimitCushionFactor * gasEstimate);
+      if (gasLimit > this.absoluteGasLimit) {
+        return new Error(`Error on deposit: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.absoluteGasLimit})...`);
       }
       const tx: ContractTransaction = await tokenContract.deposit(
         assets, 
@@ -1174,9 +1174,9 @@ export class Panoptic {
         wallet.address,
         wallet.address
       )).toNumber();
-      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      if (gasLimit > this.gasLimitEstimate) {
-        return new Error(`Error on withdraw: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      const gasLimit: number = Math.ceil(this.gasLimitCushionFactor * gasEstimate);
+      if (gasLimit > this.absoluteGasLimit) {
+        return new Error(`Error on withdraw: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.absoluteGasLimit})...`);
       }
       const tx: ContractTransaction = await tokenContract.withdraw(
         assets,

--- a/src/connectors/panoptic/panoptic.ts
+++ b/src/connectors/panoptic/panoptic.ts
@@ -1011,10 +1011,12 @@ export class Panoptic {
       const panopticpool = this.PanopticPool;
       const panopticPoolContract = new Contract(panopticpool, panopticPoolAbi.abi, wallet);
       const gasEstimate: number = (await panopticPoolContract.estimateGas.pokeMedian()).toNumber();
-      const gasLimit: number = (this.gasFactor * gasEstimate);
-      console.log(`Estimated Gas: ${gasEstimate}, gasFactor: ${this.gasFactor}, gasLimit: ${gasLimit}`);
+      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      if (gasLimit > this.gasLimitEstimate) {
+        return new Error(`Error on pokeMedian: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      }
       const tx: ContractTransaction = await panopticPoolContract.pokeMedian(
-        { gasLimit: gasLimit}
+        { gasLimit: BigNumber.from(gasLimit)}
       );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;

--- a/src/connectors/panoptic/panoptic.ts
+++ b/src/connectors/panoptic/panoptic.ts
@@ -889,16 +889,16 @@ export class Panoptic {
     try {
       const panopticpool = this.PanopticPool;
       const panopticPoolContract = new Contract(panopticpool, panopticPoolAbi.abi, wallet);
-      // const gasEstimate: number = (await panopticPoolContract.estimateGas.panopticPoolContract["burnOptions(uint256,uint256[],int24,int24)"](
-      //   burnTokenId,
-      //   newPositionIdList,
-      //   tickLimitLow,
-      //   tickLimitHigh
-      // )).toNumber();
-      // const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
-      // if (gasLimit > this.gasLimitEstimate) {
-      //   return new Error(`Error on executeBurn: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
-      // }
+      const gasEstimate: number = (await panopticPoolContract.estimateGas["burnOptions(uint256,uint256[],int24,int24)"](
+        burnTokenId,
+        newPositionIdList,
+        tickLimitLow,
+        tickLimitHigh
+      )).toNumber();
+      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      if (gasLimit > this.gasLimitEstimate) {
+        return new Error(`Error on executeBurn: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      }
       const tx: ContractTransaction = await panopticPoolContract["burnOptions(uint256,uint256[],int24,int24)"](
         burnTokenId,
         newPositionIdList,

--- a/src/connectors/panoptic/panoptic.ts
+++ b/src/connectors/panoptic/panoptic.ts
@@ -889,12 +889,22 @@ export class Panoptic {
     try {
       const panopticpool = this.PanopticPool;
       const panopticPoolContract = new Contract(panopticpool, panopticPoolAbi.abi, wallet);
+      const gasEstimate: number = (await panopticPoolContract["burnOptions(uint256,uint256[],int24,int24)"].estimateGas.burnOptions(
+        burnTokenId,
+        newPositionIdList,
+        tickLimitLow,
+        tickLimitHigh
+      )).toNumber();
+      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      if (gasLimit > this.gasLimitEstimate) {
+        return new Error(`Error on executeBurn: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      }
       const tx: ContractTransaction = await panopticPoolContract["burnOptions(uint256,uint256[],int24,int24)"](
         burnTokenId,
         newPositionIdList,
         tickLimitLow,
         tickLimitHigh,
-        { gasLimit: this.gasLimitEstimate }
+        { gasLimit: BigNumber.from(gasLimit) }
       );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;
@@ -912,12 +922,22 @@ export class Panoptic {
     try {
       const panopticpool = this.PanopticPool;
       const panopticPoolContract = new Contract(panopticpool, panopticPoolAbi.abi, wallet);
+      const gasEstimate: number = (await panopticPoolContract.estimateGas.forceExercise(
+        wallet.address,
+        touchedId,
+        positionIdListExercisee,
+        positionIdListExercisor
+      )).toNumber();
+      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      if (gasLimit > this.gasLimitEstimate) {
+        return new Error(`Error on forceExercise: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      }
       const tx: ContractTransaction = await panopticPoolContract.forceExercise(
         wallet.address,
         touchedId,
         positionIdListExercisee,
         positionIdListExercisor,
-        { gasLimit: this.gasLimitEstimate }
+        { gasLimit: BigNumber.from(gasLimit) }
       );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;
@@ -936,12 +956,22 @@ export class Panoptic {
     try {
       const panopticpool = this.PanopticPool;
       const panopticPoolContract = new Contract(panopticpool, panopticPoolAbi.abi, wallet);
+      const gasEstimate: number = (await panopticPoolContract.estimateGas.liquidate(
+        positionIdListLiquidator,
+        liquidatee,
+        delegations,
+        positionIdList
+      )).toNumber();
+      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      if (gasLimit > this.gasLimitEstimate) {
+        return new Error(`Error on liquidate: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      }
       const tx: ContractTransaction = await panopticPoolContract.liquidate(
         positionIdListLiquidator,
         liquidatee,
         delegations,
         positionIdList,
-        { gasLimit: this.gasLimitEstimate }
+        { gasLimit: BigNumber.from(gasLimit) }
       );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;
@@ -961,13 +991,24 @@ export class Panoptic {
     try {
       const panopticpool = this.PanopticPool;
       const panopticPoolContract = new Contract(panopticpool, panopticPoolAbi.abi, wallet);
+      const gasEstimate: number = (await panopticPoolContract.estimateGas.mintOptions(
+        positionIdList,
+        positionSize,
+        effectiveLiquidityLimit,
+        tickLimitLow,
+        tickLimitHigh
+      )).toNumber();
+      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      if (gasLimit > this.gasLimitEstimate) {
+        return new Error(`Error on executeMint: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      }
       const tx: ContractTransaction = await panopticPoolContract.mintOptions(
         positionIdList,
         positionSize,
         effectiveLiquidityLimit,
         tickLimitLow,
         tickLimitHigh,
-        { gasLimit: this.gasLimitEstimate }
+        { gasLimit: BigNumber.from(gasLimit) }
       );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;
@@ -1034,11 +1075,20 @@ export class Panoptic {
     try {
       const panopticpool = this.PanopticPool;
       const panopticPoolContract = new Contract(panopticpool, panopticPoolAbi.abi, wallet);
+      const gasEstimate: number = (await panopticPoolContract.estimateGas.settleLongPremium(
+        positionIdList,
+        owner,
+        legIndex
+      )).toNumber();
+      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      if (gasLimit > this.gasLimitEstimate) {
+        return new Error(`Error on settleLongPremium: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      }
       const tx: ContractTransaction = await panopticPoolContract.settleLongPremium(
         positionIdList,
         owner,
         legIndex,
-        { gasLimit: this.gasLimitEstimate }
+        { gasLimit: BigNumber.from(gasLimit) }
       );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;
@@ -1055,7 +1105,19 @@ export class Panoptic {
   ): Promise<ContractReceipt | Error> {
     try {
       const tokenContract = new Contract(collateralTrackerContract.toString(), collateralTrackerAbi.abi, wallet);
-      const tx: ContractTransaction = await tokenContract.deposit(assets, wallet.address, { gasLimit: this.gasLimitEstimate });
+      const gasEstimate: number = (await tokenContract.estimateGas.deposit(
+        assets, 
+        wallet.address
+      )).toNumber();
+      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      if (gasLimit > this.gasLimitEstimate) {
+        return new Error(`Error on deposit: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      }
+      const tx: ContractTransaction = await tokenContract.deposit(
+        assets, 
+        wallet.address, 
+        { gasLimit: BigNumber.from(gasLimit) }
+      );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;
     } catch (error) {
@@ -1107,11 +1169,20 @@ export class Panoptic {
   ): Promise<ContractReceipt | Error> {
     try {
       const tokenContract = new Contract(collateralTrackerContract.toString(), collateralTrackerAbi.abi, wallet);
+      const gasEstimate: number = (await tokenContract.estimateGas.withdraw(
+        assets,
+        wallet.address,
+        wallet.address
+      )).toNumber();
+      const gasLimit: number = Math.ceil(this.gasFactor * gasEstimate);
+      if (gasLimit > this.gasLimitEstimate) {
+        return new Error(`Error on withdraw: Gas limit exceeded, gas estimate limit (${gasLimit}) greater than tx cap (${this.gasLimitEstimate})...`);
+      }
       const tx: ContractTransaction = await tokenContract.withdraw(
         assets,
         wallet.address,
         wallet.address,
-        { gasLimit: this.gasLimitEstimate }
+        { gasLimit: BigNumber.from(gasLimit) }
       );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;

--- a/src/connectors/panoptic/panoptic.ts
+++ b/src/connectors/panoptic/panoptic.ts
@@ -904,8 +904,7 @@ export class Panoptic {
         newPositionIdList,
         tickLimitLow,
         tickLimitHigh,
-        { gasLimit: this.gasLimitEstimate }
-        // { gasLimit: BigNumber.from(gasLimit) }
+        { gasLimit: BigNumber.from(gasLimit) }
       );
       const receipt: ContractReceipt = await tx.wait();
       return receipt;

--- a/src/services/schema/panoptic-schema.json
+++ b/src/services/schema/panoptic-schema.json
@@ -5,10 +5,10 @@
     "allowedSlippage": {
       "type": "string"
     },
-    "gasFactor": {
+    "gasLimitCushionFactor": {
       "type": "number"
     },
-    "gasLimitEstimate": {
+    "absoluteGasLimit": {
       "type": "integer"
     },
     "ttl": {
@@ -78,8 +78,8 @@
   "additionalProperties": false,
   "required": [
     "allowedSlippage",
-    "gasFactor",
-    "gasLimitEstimate",
+    "gasLimitCushionFactor",
+    "absoluteGasLimit",
     "ttl",
     "contractAddresses"
   ]

--- a/src/services/schema/panoptic-schema.json
+++ b/src/services/schema/panoptic-schema.json
@@ -5,6 +5,9 @@
     "allowedSlippage": {
       "type": "string"
     },
+    "gasFactor": {
+      "type": "number"
+    },
     "gasLimitEstimate": {
       "type": "integer"
     },
@@ -75,6 +78,7 @@
   "additionalProperties": false,
   "required": [
     "allowedSlippage",
+    "gasFactor",
     "gasLimitEstimate",
     "ttl",
     "contractAddresses"

--- a/src/templates/panoptic.yml
+++ b/src/templates/panoptic.yml
@@ -7,10 +7,10 @@ allowedSlippage: '1/100'
 ttl: 300
 
 # The estimated gas for a transaction is the `ethers` estimate for the transaction, multiplied by this factor.
-gasFactor: 1.5
+gasLimitCushionFactor: 1.5
 
 # Don't allow a Panoptic trade with an estimated gas above this amount.
-gasLimitEstimate: 10000000
+absoluteGasLimit: 10000000
 
 subgraph:
   # The subgraph endpoint to query for Panoptic data.

--- a/src/templates/panoptic.yml
+++ b/src/templates/panoptic.yml
@@ -6,8 +6,10 @@ allowedSlippage: '1/100'
 # concept. We'll remove this eventually.
 ttl: 300
 
-# The maximum gas used to estimate gasCost for a Panoptic trade. TODO: This will eventually be
-# dynamic.
+# The estimated gas for a transaction is the `ethers` estimate for the transaction, multiplied by this factor.
+gasFactor: 1.5
+
+# Don't allow a Panoptic trade with an estimated gas above this amount.
 gasLimitEstimate: 10000000
 
 subgraph:


### PR DESCRIPTION
Dynamic gas estimation added to all state-changing methods. Two gas control properties are now hard coded into the configuration of the connector - (1) a `gasFactor` which multiplies the ethers estimated gas cost and then this product is compared against (2) a `gasLimitEstimate` to determine whether or not to allow the transaction to proceed. 

Closes #7 

