### PR TITLE
Removing ttl and allowedSlippage parameters

### DIFF
--- a/src/connectors/panoptic/panoptic.config.ts
+++ b/src/connectors/panoptic/panoptic.config.ts
@@ -6,7 +6,6 @@ export namespace PanopticConfig {
     allowedSlippage: string;
     absoluteGasLimit: number;
     gasLimitCushionFactor: number; 
-    ttl: number;
     subgraphUrl: string;
     lowestTick: number;
     highestTick: number;
@@ -27,7 +26,6 @@ export namespace PanopticConfig {
     allowedSlippage: ConfigManagerV2.getInstance().get('panoptic.allowedSlippage'),
     gasLimitCushionFactor: ConfigManagerV2.getInstance().get('panoptic.gasLimitCushionFactor'),
     absoluteGasLimit: ConfigManagerV2.getInstance().get(`panoptic.absoluteGasLimit`),
-    ttl: ConfigManagerV2.getInstance().get('panoptic.ttl'),
     subgraphUrl: ConfigManagerV2.getInstance().get('panoptic.subgraph.endpoint'),
     lowestTick: ConfigManagerV2.getInstance().get('panoptic.lowestTick'),
     highestTick: ConfigManagerV2.getInstance().get('panoptic.highestTick'),

--- a/src/connectors/panoptic/panoptic.config.ts
+++ b/src/connectors/panoptic/panoptic.config.ts
@@ -3,7 +3,6 @@ import { ConfigManagerV2 } from '../../services/config-manager-v2';
 
 export namespace PanopticConfig {
   export interface NetworkConfig {
-    allowedSlippage: string;
     absoluteGasLimit: number;
     gasLimitCushionFactor: number; 
     subgraphUrl: string;
@@ -23,7 +22,6 @@ export namespace PanopticConfig {
   }
 
   export const config: NetworkConfig = {
-    allowedSlippage: ConfigManagerV2.getInstance().get('panoptic.allowedSlippage'),
     gasLimitCushionFactor: ConfigManagerV2.getInstance().get('panoptic.gasLimitCushionFactor'),
     absoluteGasLimit: ConfigManagerV2.getInstance().get(`panoptic.absoluteGasLimit`),
     subgraphUrl: ConfigManagerV2.getInstance().get('panoptic.subgraph.endpoint'),

--- a/src/connectors/panoptic/panoptic.ts
+++ b/src/connectors/panoptic/panoptic.ts
@@ -33,7 +33,6 @@ export class Panoptic {
   private _TokenIdLibrary: string;
   private _absoluteGasLimit: number;
   private _gasLimitCushionFactor: number;
-  private _ttl: number;
   private _subgraphUrl: string;
   private _lowestTick: number;
   private _highestTick: number;
@@ -55,7 +54,6 @@ export class Panoptic {
     this._PanopticHelper = config.PanopticHelper(chain, network);
     this._UniswapMigrator = config.UniswapMigrator(chain, network);
     this._TokenIdLibrary = config.TokenIdLibrary(chain, network);
-    this._ttl = config.ttl;
     this._subgraphUrl = config.subgraphUrl;
     this._lowestTick = config.lowestTick;
     this._highestTick = config.highestTick;
@@ -147,9 +145,6 @@ export class Panoptic {
   }
   public get gasLimitCushionFactor(): number {
     return this._gasLimitCushionFactor;
-  }
-  public get ttl(): number {
-    return this._ttl;
   }
   public get subgraphUrl(): string {
     return this._subgraphUrl;

--- a/src/options/options.validators.ts
+++ b/src/options/options.validators.ts
@@ -1,6 +1,5 @@
 import {
   isFloatString,
-  isFractionString,
   mkValidator,
   mkRequestValidator,
   RequestValidator,

--- a/src/options/options.validators.ts
+++ b/src/options/options.validators.ts
@@ -51,9 +51,6 @@ export const invalidTimeError: string =
 export const invalidDecreasePercentError: string =
   'If decreasePercent is included it must be a non-negative integer.';
 
-export const invalidAllowedSlippageError: string =
-  'The allowedSlippage param may be null or a string of a fraction.';
-
 export const invalidPoolIdError: string =
   'PoolId(if supplied) must be a string.';
 
@@ -198,13 +195,6 @@ export const validateDecreasePercent: Validator = mkValidator(
   (val) =>
     typeof val === 'undefined' ||
     (typeof val === 'number' && val >= 0 && Number.isFinite(val)),
-  true
-);
-
-export const validateAllowedSlippage: Validator = mkValidator(
-  'allowedSlippage',
-  invalidAllowedSlippageError,
-  (val) => typeof val === 'string' && (isFractionString(val) || val.includes('%')),
   true
 );
 

--- a/src/services/schema/panoptic-schema.json
+++ b/src/services/schema/panoptic-schema.json
@@ -11,9 +11,6 @@
     "absoluteGasLimit": {
       "type": "integer"
     },
-    "ttl": {
-      "type": "integer"
-    },
     "lowestTick": {
       "type": "integer"
     },
@@ -77,7 +74,6 @@
     "allowedSlippage",
     "gasLimitCushionFactor",
     "absoluteGasLimit",
-    "ttl",
     "contractAddresses"
   ]
 }

--- a/src/services/schema/panoptic-schema.json
+++ b/src/services/schema/panoptic-schema.json
@@ -2,9 +2,6 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "type": "object",
   "properties": {
-    "allowedSlippage": {
-      "type": "string"
-    },
     "gasLimitCushionFactor": {
       "type": "number"
     },
@@ -71,7 +68,6 @@
   },
   "additionalProperties": false,
   "required": [
-    "allowedSlippage",
     "gasLimitCushionFactor",
     "absoluteGasLimit",
     "contractAddresses"

--- a/src/templates/panoptic.yml
+++ b/src/templates/panoptic.yml
@@ -1,7 +1,3 @@
-# allowedSlippage: how much the execution price is allowed to move unfavorably from the trade
-# execution price. It uses a rational number for precision.
-allowedSlippage: '1/100'
-
 # The estimated gas for a transaction is the `ethers` estimate for the transaction, multiplied by this factor.
 gasLimitCushionFactor: 1.5
 

--- a/src/templates/panoptic.yml
+++ b/src/templates/panoptic.yml
@@ -2,10 +2,6 @@
 # execution price. It uses a rational number for precision.
 allowedSlippage: '1/100'
 
-# ttl: how long a trade is valid in seconds. TODO: This is a placeholder; Panoptic has no such
-# concept. We'll remove this eventually.
-ttl: 300
-
 # The estimated gas for a transaction is the `ethers` estimate for the transaction, multiplied by this factor.
 gasLimitCushionFactor: 1.5
 


### PR DESCRIPTION
Removing both the "ttl" and "allowedSlippage" parameters, neither of which is used by Panoptic connector. 


Closes #31 